### PR TITLE
layers/X: fixup checksum mismatch

### DIFF
--- a/packages/layers/X/build.yaml
+++ b/packages/layers/X/build.yaml
@@ -9,6 +9,10 @@ excludes:
 - ^/var/log
 env:
 - JOBS={{ ( index .Values.labels "emerge.jobs" ) | default "3" }}
+
+prelude:
+- cd /var/db/repos/gentoo/net-dialup/ppp && rm Manifest && ebuild ppp-2.4.8.ebuild digest
+
 steps:
 - emerge -j ${JOBS} {{ ( index .Values.labels "emerge.packages" ) }}
 - cp -rv xorg.conf.d/ /etc/X11/


### PR DESCRIPTION
Seems upstream changed the patchset without a revbump:

```

>>> Downloading
'https://dev.gentoo.org/~polynomial-c/ppp-2.4.8-patches-02.tar.xz'
--2021-01-13 1130--
https://dev.gentoo.org/~polynomial-c/ppp-2.4.8-patches-02.tar.xz
Resolving dev.gentoo.org... 140.211.166.183, 2001ea4a5054fec7:86e4
Connecting to dev.gentoo.org|140.211.166.183|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 39868 (39K) [application/x-xz]
Saving to:
‘/var/cache/distfiles/ppp-2.4.8-patches-02.tar.xz.__download__’

     0K .......... .......... .......... ........             100%
479K=0.08s

2021-01-13 1130 (479 KB/s) -
‘/var/cache/distfiles/ppp-2.4.8-patches-02.tar.xz.__download__’ saved
[39868/39868]

!!! Fetched file: ppp-2.4.8-patches-02.tar.xz VERIFY FAILED!
!!! Reason: Filesize does not match recorded size
!!! Got:      39868
!!! Expected: 39700
Refetching... File renamed to
'/var/cache/distfiles/ppp-2.4.8-patches-02.tar.xz._checksum_failure_.j5i2f8w2'

```