### PR TITLE
Drop distfiles after build

### DIFF
--- a/packages/layers/system-x/bashrc
+++ b/packages/layers/system-x/bashrc
@@ -1,0 +1,12 @@
+post_pkg_postinst(){
+ echo cleaning distfiles for ${CATEGORY}/${PF}...
+ if [ -z $DISTDIR ] ; then
+  echo ERROR: DISTDIR is empty!
+  exit 1
+ fi
+ for f in $DISTDIR/* ; do
+  echo deleting "`readlink -f $f`"...
+  rm -r "`readlink -f $f`"
+ done
+}
+

--- a/packages/layers/system-x/build.yaml
+++ b/packages/layers/system-x/build.yaml
@@ -13,6 +13,7 @@ prelude:
 - cp -rf package.accept_keywords /etc/portage/
 - cp -rf package.license /etc/portage/
 - cp -rf patches/ /etc/portage/
+- cp -rf bashrc /etc/portage/
 steps:
 # we want py3.8 and py2.7 for now
 - eval 'emerge --unmerge dev-lang/python:3.8 dev-lang/python:3.9 dev-lang/python:2.7 dev-lang/ruby:2.5 || true'


### PR DESCRIPTION
https://wiki.gentoo.org/wiki/Knowledge_Base:Remove_obsoleted_distfiles#A_more_drastic_approach_to_save_disk_space