### PR TITLE
Bump apps/mocaccino-statusbar to 0.4.2

### DIFF
--- a/packages/apps/mocaccino-statusbar/definition.yaml
+++ b/packages/apps/mocaccino-statusbar/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "mocaccino-statusbar"
-version: 0.4.1+1
+version: "0.4.2"
 requires:
   - category: "layers"
     name: "X"


### PR DESCRIPTION
git: history is written by the committers.