### PR TITLE
apps/emacs: copy package.use file

### DIFF
--- a/packages/apps/emacs/build.yaml
+++ b/packages/apps/emacs/build.yaml
@@ -1,3 +1,6 @@
+prelude:
+- cp -rf package.use /etc/portage/
+
 excludes:
 - ^/var/cache/distfiles
 - ^/usr/portage/distfiles


### PR DESCRIPTION
There is a `package.use/01-emacs.use` file but it is never copied to
`/etc/portage/packages.use` directory. This commit adds a prelude to
copy the file over.

The flags added by the file do not cause any alterations on the atoms
requried.

This closes mocaccinoos/desktop#163.