### PR TITLE
apps/emacs: Add GUI

### DIFF
--- a/packages/apps/emacs/definition.yaml
+++ b/packages/apps/emacs/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "emacs"
-version: 27.1+16
+version: 27.1+17
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/emacs/package.use/01-emacs.use
+++ b/packages/apps/emacs/package.use/01-emacs.use
@@ -1,1 +1,2 @@
-app-editors/emacs libxml2 xft
+app-editors/emacs libxml2 xft gui
+app-emacs/emacs-common gui


### PR DESCRIPTION
This commit enables the emacs gui and does revbump. These changes do not add/remove atoms.

It closes mocaccinoos/desktop#154.