### PR TITLE
rebuild initrd for new modules and modprobe rules

### DIFF
--- a/packages/kernel-modules/kernel-modules/finalize.yaml
+++ b/packages/kernel-modules/kernel-modules/finalize.yaml
@@ -1,2 +1,3 @@
 install:
 - depmod -a
+- mos kernel gi --all --grub --set-links


### PR DESCRIPTION
**WARNING: DO NOT MERGE THIS PR IF ADDITIONAL KERNEL MODULES ARE ADDED BY DEFAULT IN THE ISO!**

Adding kernel modules can result in the need to add the modules to the initramfs for proper early boot support. (KMS for example)
Adding kernel modules can also add modprobe rules to /etc/modprobe.d/ . Those rules will not take affect until the initramfs is rebuilt and included.