### PR TITLE
Bump layers/gentoo-portage to 0.20210822

### DIFF
--- a/packages/apps/calamares/definition.yaml
+++ b/packages/apps/calamares/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "calamares"
-version: 3.2.32+55
+version: 3.2.32+56
 provides:
   - name: calamares
     category: app-admin

--- a/packages/apps/discover/definition.yaml
+++ b/packages/apps/discover/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "discover"
-version: 5.21.5+23
+version: 5.21.5+24
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/emacs/definition.yaml
+++ b/packages/apps/emacs/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "emacs"
-version: 27.1+27
+version: 27.1+28
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/firefox/definition.yaml
+++ b/packages/apps/firefox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "firefox"
-version: 78.12.0+7
+version: 78.12.0+8
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/fish/definition.yaml
+++ b/packages/apps/fish/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "fish"
-version: 3.1.2+6
+version: 3.1.2+7
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/flatpak/definition.yaml
+++ b/packages/apps/flatpak/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "flatpak"
-version: 1.10.2+19
+version: 1.10.2+20
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/gnome-software/definition.yaml
+++ b/packages/apps/gnome-software/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "gnome-software"
-version: 40.2+23
+version: 40.2+24
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/gnumeric/definition.yaml
+++ b/packages/apps/gnumeric/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "gnumeric"
-version: 1.12.48+27
+version: 1.12.48+28
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/google-chrome/definition.yaml
+++ b/packages/apps/google-chrome/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "google-chrome"
-version: 91.0.4472.114+17
+version: 91.0.4472.114+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/gparted/definition.yaml
+++ b/packages/apps/gparted/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "gparted"
-version: 1.3.0+17
+version: 1.3.0+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/grub/definition.yaml
+++ b/packages/apps/grub/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "grub"
-version: 2.04+44
+version: 2.04+45
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/guake/definition.yaml
+++ b/packages/apps/guake/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "guake"
-version: 3.7.0+35
+version: 3.7.0+36
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/hexchat/definition.yaml
+++ b/packages/apps/hexchat/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "hexchat"
-version: 2.14.3+39
+version: 2.14.3+40
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/htop/definition.yaml
+++ b/packages/apps/htop/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "htop"
-version: 3.0.5+17
+version: 3.0.5+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/i3/definition.yaml
+++ b/packages/apps/i3/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "i3"
-version: 4.18+28
+version: 4.18+29
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/kate/definition.yaml
+++ b/packages/apps/kate/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "kate"
-version: 20.12.3+16
+version: 20.12.3+17
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/krusader/definition.yaml
+++ b/packages/apps/krusader/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "krusader"
-version: 2.7.2+16
+version: 2.7.2+17
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/late-dock/definition.yaml
+++ b/packages/apps/late-dock/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "latte-dock"
-version: 0.9.12+17
+version: 0.9.12+18
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/lightdm/definition.yaml
+++ b/packages/apps/lightdm/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "lightdm"
-version: 1.30.0+37
+version: 1.30.0+38
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/mc/definition.yaml
+++ b/packages/apps/mc/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "mc"
-version: 4.8.26+38
+version: 4.8.26+39
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/mesa-progs/definition.yaml
+++ b/packages/apps/mesa-progs/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "mesa-progs"
-version: 8.4.0+36
+version: 8.4.0+37
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/mocaccino-statusbar/definition.yaml
+++ b/packages/apps/mocaccino-statusbar/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "mocaccino-statusbar"
-version: 0.4.2+33
+version: 0.4.2+34
 requires:
   - category: "layers"
     name: "X"

--- a/packages/apps/mpv/definition.yaml
+++ b/packages/apps/mpv/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "mpv"
-version: 0.33.1+31
+version: 0.33.1+32
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/apps/nnn/definition.yaml
+++ b/packages/apps/nnn/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "nnn"
-version: 4.0+18
+version: 4.0+19
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/opera/definition.yaml
+++ b/packages/apps/opera/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "opera"
-version: 77.0.4054.90+17
+version: 77.0.4054.90+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/slim/definition.yaml
+++ b/packages/apps/slim/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "slim"
-version: 1.3.6+39
+version: 1.3.6+40
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/steam/definition.yaml
+++ b/packages/apps/steam/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "steam"
-version: 20210323+31
+version: 20210323+32
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/teamviewer/definition.yaml
+++ b/packages/apps/teamviewer/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "teamviewer"
-version: 15.19.3+17
+version: 15.19.3+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/thunderbird/definition.yaml
+++ b/packages/apps/thunderbird/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "thunderbird"
-version: 78.12.0+7
+version: 78.12.0+8
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/tmux/definition.yaml
+++ b/packages/apps/tmux/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "tmux"
-version: 3.1+11
+version: 3.1+12
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/transmission/definition.yaml
+++ b/packages/apps/transmission/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "transmission"
-version: 3.00+39
+version: 3.00+40
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/vim/definition.yaml
+++ b/packages/apps/vim/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "vim"
-version: 8.2.0814+38
+version: 8.2.0814+39
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/virtualbox/definition.yaml
+++ b/packages/apps/virtualbox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "virtualbox"
-version: 6.1.22+11
+version: 6.1.22+12
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/vivaldi/definition.yaml
+++ b/packages/apps/vivaldi/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "vivaldi"
-version: 4.0.2312.33+17
+version: 4.0.2312.33+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/vlc/definition.yaml
+++ b/packages/apps/vlc/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "vlc"
-version: 3.0.14+17
+version: 3.0.14+18
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/weechat/definition.yaml
+++ b/packages/apps/weechat/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "weechat"
-version: 3.1+8
+version: 3.1+9
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/apps/zsh/definition.yaml
+++ b/packages/apps/zsh/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "zsh"
-version: 5.8+32
+version: 5.8+33
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -21,7 +21,7 @@ packages:
       lts.kernel: "true"
   - category: "kernel-modules"
     name: "virtualbox-guest-additions-lts"
-    version: 6.1.22+16
+    version: 6.1.22+17
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - category: "kernel-modules"
     name: "virtualbox-modules"
-    version: 3+13
+    version: 3+14
     lts: false
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -11,7 +11,7 @@ packages:
       lts.kernel: "false"
   - category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 3+33
+    version: 3+34
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -52,7 +52,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-lts"
-    version: 0.993+8
+    version: 0.993+9
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/sources/collection.yaml
+++ b/packages/kernel-modules/sources/collection.yaml
@@ -14,7 +14,7 @@ packages:
       package.version: "5.10.49"
   - category: "kernel-sources"
     name: "mocaccino-sources"
-    version: 5.13.1+14
+    version: 5.13.1+15
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'

--- a/packages/kernel-modules/sources/collection.yaml
+++ b/packages/kernel-modules/sources/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - category: "kernel-sources"
     name: "mocaccino-lts-sources"
-    version: 5.10.49+10
+    version: 5.10.49+11
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'

--- a/packages/layers/X/definition.yaml
+++ b/packages/layers/X/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "X"
-version: 0.8+11
+version: 0.8+12
 labels:
   emerge.jobs: "8"
   emerge.packages: >-

--- a/packages/layers/cinnamon/definition.yaml
+++ b/packages/layers/cinnamon/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "cinnamon"
-version: 4.6.7+33
+version: 4.6.7+34
 labels:
   emerge.jobs: "3"
   emerge.packages: "gnome-extra/cinnamon"

--- a/packages/layers/codecs/definition.yaml
+++ b/packages/layers/codecs/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "codecs"
-version: 3+11
+version: 3+12
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/layers/enlightenment/definition.yaml
+++ b/packages/layers/enlightenment/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "enlightenment"
-version: 0.24.2+36
+version: 0.24.2+37
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/firmware/definition.yaml
+++ b/packages/layers/firmware/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "firmware"
-version: 1+40
+version: 1+41
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/gnome-common/definition.yaml
+++ b/packages/layers/gnome-common/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "gnome-common"
-version: 0.8+19
+version: 0.8+20
 labels:
   emerge.jobs: "6"
   emerge.packages: >-

--- a/packages/layers/gnome/definition.yaml
+++ b/packages/layers/gnome/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "gnome"
-version: 40.0+23
+version: 40.0+24
 labels:
   emerge.jobs: "3"
   emerge.packages: "app-arch/file-roller gnome-base/dconf-editor gnome-base/gnome gnome-extra/gnome-calculator gnome-extra/gnome-power-manager gnome-extra/gnome-system-monitor gnome-extra/gnome-tweaks gnome-extra/gnome-weather media-gfx/gnome-screenshot media-gfx/shotwell sys-apps/gnome-disk-utility"

--- a/packages/layers/kde-apps-minimal/definition.yaml
+++ b/packages/layers/kde-apps-minimal/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "kde-apps-minimal"
-version: 20.12.3+18
+version: 20.12.3+19
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/kde-common/definition.yaml
+++ b/packages/layers/kde-common/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "kde-common"
-version: 3+1
+version: 3+2
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/layers/kde-pim/definition.yaml
+++ b/packages/layers/kde-pim/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "kde-pim"
-version: 21.04.3+9
+version: 21.04.3+10
 labels:
   emerge.jobs: "3"
   emerge.packages: >-

--- a/packages/layers/lxqt/definition.yaml
+++ b/packages/layers/lxqt/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "lxqt"
-version: 0.16.0+29
+version: 0.16.0+30
 labels:
   emerge.jobs: "6"
   emerge.packages: >-

--- a/packages/layers/mate/definition.yaml
+++ b/packages/layers/mate/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "mate"
-version: 1.24+52
+version: 1.24+53
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/net-tools/definition.yaml
+++ b/packages/layers/net-tools/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "net-tools"
-version: 0.2+7
+version: 0.2+8
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/plasma/definition.yaml
+++ b/packages/layers/plasma/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "plasma"
-version: 5.21.5+20
+version: 5.21.5+21
 labels:
   emerge.jobs: "6"
   emerge.packages: >-

--- a/packages/layers/qt/definition.yaml
+++ b/packages/layers/qt/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "qt"
-version: 5.15.2+55
+version: 5.15.2+56
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/sys-fs/definition.yaml
+++ b/packages/layers/sys-fs/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "sys-fs"
-version: 0.5+48
+version: 0.5+49
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/layers/system-x/definition.yaml
+++ b/packages/layers/system-x/definition.yaml
@@ -1,5 +1,5 @@
 name: system-x
-version: "0.20210827"
+version: 0.20210827+1
 category: layers
 requires:
   - category: "system"

--- a/packages/layers/system-x/devel/definition.yaml
+++ b/packages/layers/system-x/devel/definition.yaml
@@ -1,5 +1,5 @@
 name: system-x-devel
-version: 0.20201125+42
+version: 0.20201125+43
 category: layers
 packages:
   - {}

--- a/packages/layers/system-x/gcc-base/definition.yaml
+++ b/packages/layers/system-x/gcc-base/definition.yaml
@@ -1,6 +1,6 @@
 name: "gcc-base"
 category: "system"
-version: 10.3.0+19
+version: 10.3.0+20
 gcc_version: "10.3.0"
 labels:
   llvm_slot: "12"

--- a/packages/layers/system-x/gcc/definition.yaml
+++ b/packages/layers/system-x/gcc/definition.yaml
@@ -1,3 +1,3 @@
 name: "gcc"
 category: "development"
-version: 10.3.0+18
+version: 10.3.0+19

--- a/packages/layers/xfce/definition.yaml
+++ b/packages/layers/xfce/definition.yaml
@@ -1,6 +1,6 @@
 category: "layers"
 name: "xfce"
-version: 4.14+40
+version: 4.14+41
 labels:
   emerge.jobs: "1"
   emerge.packages: >-

--- a/packages/themes/mate/definition.yaml
+++ b/packages/themes/mate/definition.yaml
@@ -1,6 +1,6 @@
 category: "themes"
 name: "mate"
-version: 1+12
+version: 1+13
 labels:
 requires:
   - category: "layers"


### PR DESCRIPTION
Ans. - because it's scripted.