### PR TITLE
Specify kernel-version in depmod call

### DIFF
--- a/packages/kernel-modules/kernel-modules/finalize.yaml
+++ b/packages/kernel-modules/kernel-modules/finalize.yaml
@@ -1,2 +1,6 @@
 install:
-- depmod -a
+- |
+  for KER in  $(ls /lib/modules/)
+  do
+    depmod -a $KER
+  done


### PR DESCRIPTION
Specifying kernel version in kernel/modules allow depmod to be call for the good kernel.
This way, modules can be used in iso.
It handle issue [#215](https://github.com/mocaccinoOS/desktop/issues/215)