### PR TITLE
Bump kernel/mocaccino-minimal to 5.18.6

### DIFF
--- a/packages/kernels/kernels/mocaccino/minimal/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/minimal/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-minimal
 category: kernel
-version: "5.18.5"
+version: "5.18.6"
 kernelprefix: kernel-vanilla
 suffix: mocaccino
 arch: "x86_64"
@@ -17,4 +17,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.18.5"
+  package.version: "5.18.6"


### PR DESCRIPTION
git: history is written by the committers.