### PR TITLE
Bump kernel/mocaccino-lts-modules to 5.15.49

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "5.15.48"
+version: "5.15.50"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.15.48"
+  package.version: "5.15.50"


### PR DESCRIPTION
git-stash: The sock drawer of version control