### PR TITLE
Bump kernel-sources/mocaccino-sources to 5.18.11

### DIFF
--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -16,7 +16,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true
-    version: 5.18.7+3
+    version: "5.18.12"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -26,4 +26,4 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-      package.version: "5.18.7"
+      package.version: "5.18.12"


### PR DESCRIPTION
![titanic](./images/titanic-float-none.png)