### PR TITLE
Bump kernel/mocaccino-sources to 5.19.6

### DIFF
--- a/packages/kernels/kernels/mocaccino/sources/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-sources
 category: kernel
-version: "5.19.4"
+version: "5.19.9"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.19.4"
+  package.version: "5.19.9"


### PR DESCRIPTION
git request-pull: only legal in Nevada.