### PR TITLE
Bump kernel/mocaccino-full to 5.19.14

### DIFF
--- a/packages/kernels/kernels/mocaccino/kernel/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/kernel/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-full
 category: kernel
-version: "5.19.11"
+version: "5.19.14"
 requires:
   - name: "mocaccino-modules"
     category: "kernel"
@@ -22,4 +22,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.19.11"
+  package.version: "5.19.14"


### PR DESCRIPTION
Answer: ![umbrella](./images/umbrella.gif)