### PR TITLE
Bump kernel/mocaccino-lts-sources to 5.15.74

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/sources/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-sources
 category: kernel
-version: "5.15.72"
+version: "5.15.74"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.15.72"
+  package.version: "5.15.74"


### PR DESCRIPTION
We're gits of the round table! | We eat ham and jam and commitalot! | On second thought, let's not go to #gitalot. It is a silly place.