### PR TITLE
Bump kernel/mocaccino-lts-minimal to 5.15.86

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/minimal/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/minimal/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-minimal
 category: kernel
-version: "5.15.85"
+version: "5.15.88"
 kernelprefix: kernel-vanilla
 arch: "x86_64"
 suffix: mocaccino
@@ -18,4 +18,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.15.85"
+  package.version: "5.15.88"


### PR DESCRIPTION
git-cherry-pick does not yield actual delicious cherries