### PR TITLE
Bump kernel/mocaccino-sources to 6.1.11

### DIFF
--- a/packages/kernels/kernels/mocaccino/sources/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-sources
 category: kernel
-version: "6.1.9"
+version: "6.1.12"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "6.1.9"
+  package.version: "6.1.12"


### PR DESCRIPTION
Because it has Hooks 😂.