### PR TITLE
Bump kernel/mocaccino-minimal to 6.2.1

### DIFF
--- a/packages/kernels/kernels/mocaccino/minimal/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/minimal/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-minimal
 category: kernel
-version: "6.1.12"
+version: "6.2.1"
 kernelprefix: kernel-vanilla
 suffix: mocaccino
 arch: "x86_64"
@@ -17,4 +17,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "6.1.12"
+  package.version: "6.2.1"


### PR DESCRIPTION
Commits are not objects of love, and should not be judged by their size.