### PR TITLE
Bump kernel/mocaccino-full to 6.2.2

### DIFF
--- a/packages/kernels/kernels/mocaccino/kernel/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/kernel/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-full
 category: kernel
-version: "6.2.1"
+version: "6.2.2"
 requires:
   - name: "mocaccino-modules"
     category: "kernel"
@@ -25,4 +25,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "6.2.1"
+  package.version: "6.2.2"


### PR DESCRIPTION
git-sweep: It's brooms, all the way down.