### PR TITLE
Bump kernel-sources/mocaccino-lts-sources to 6.1.21

### DIFF
--- a/packages/apps/virtualbox/definition.yaml
+++ b/packages/apps/virtualbox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "virtualbox"
-version: 7.0.6-r2+5
+version: 7.0.6-r2+6
 uri:
   - https://www.virtualbox.org
 license: "GPL-2"

--- a/packages/buildbases/collection.yaml
+++ b/packages/buildbases/collection.yaml
@@ -24,7 +24,7 @@ packages:
   - !!merge <<: *X
     real_category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 0+145
+    version: 0+146
   - !!merge <<: *X
     real_category: "apps"
     name: "pavucontrol-qt"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -257,7 +257,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "vhba-lts"
-    version: 20211218+37
+    version: 20211218+38
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -15,7 +15,7 @@ packages:
   #        version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 7.0.4+19
+    version: 7.0.4+20
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -141,7 +141,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-470-lts"
-    version: 470.161.03+35
+    version: 470.161.03+36
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -67,7 +67,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-lts"
-    version: 525.89.02+1
+    version: 525.89.02+2
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -191,7 +191,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xpadneo-lts"
-    version: 0.9.5+47
+    version: 0.9.5+48
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -166,7 +166,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-legacy-lts"
-    version: 390.157+35
+    version: 390.157+36
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -235,7 +235,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8812au-lts"
-    version: 20220827+45
+    version: 20220827+46
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -116,7 +116,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-510-lts"
-    version: 510.108.03+35
+    version: 510.108.03+36
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -213,7 +213,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xone-lts"
-    version: 0.3+47
+    version: 0.3+48
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -279,7 +279,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl88x2bu-lts"
-    version: 20211010+28
+    version: 20211010+29
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -30,7 +30,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-guest-additions-lts"
-    version: 7.0.4+19
+    version: 7.0.4+20
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-lts-sources"
     hidden: true
-    version: 6.1.20+1
+    version: "6.1.21"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -12,7 +12,7 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "6.1.20"
+      package.version: "6.1.21"
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true


### PR DESCRIPTION
Gits N' Roses: Now with more git cherry-pop, git freebase, and starring git Slash!