### PR TITLE
Bump kernel/mocaccino-lts-modules to 6.1.22

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "6.1.21"
+version: "6.1.22"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.21"
+  package.version: "6.1.22"


### PR DESCRIPTION
![Tests](./images/tests.png)