### PR TITLE
Bump kernel/mocaccino-modules to 6.2.13

### DIFF
--- a/packages/kernels/kernels/mocaccino/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-modules
 category: kernel
-version: "6.2.12"
+version: "6.2.13"
 prefix: linux
 suffix: mocaccino
 arch: "x86_64"
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "6.2.12"
+  package.version: "6.2.13"


### PR DESCRIPTION
git-prune: not as tasty as git-cherry, but much better for you