### PR TITLE
Bump kernel/mocaccino-lts-initramfs to 6.1.27

### DIFF
--- a/packages/kernels/initramfs/collection.yaml
+++ b/packages/kernels/initramfs/collection.yaml
@@ -19,7 +19,7 @@ packages:
   - category: "kernel"
     name: "mocaccino-lts-initramfs"
     modules_name: "mocaccino-lts-modules"
-    version: "6.1.26"
+    version: "6.1.27"
     git_sha: e80e77438c627981b266734c03e23dcf8a60014e
     golang_version: "1.19.1"
     arch: "amd64"
@@ -32,4 +32,4 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "6.1.26"
+      package.version: "6.1.27"


### PR DESCRIPTION
git-prune: not as tasty as git-cherry, but much better for you