### PR TITLE
Bump kernel-sources/mocaccino-lts-sources to 6.1.29

### DIFF
--- a/packages/apps/virtualbox/definition.yaml
+++ b/packages/apps/virtualbox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "virtualbox"
-version: 7.0.6-r2+20
+version: 7.0.6-r2+21
 uri:
   - https://www.virtualbox.org
 license: "GPL-2"

--- a/packages/buildbases/collection.yaml
+++ b/packages/buildbases/collection.yaml
@@ -28,7 +28,7 @@ packages:
   - !!merge <<: *X
     real_category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 0+161
+    version: 0+162
   - !!merge <<: *X
     real_category: "apps"
     name: "pavucontrol-qt"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -257,7 +257,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "vhba-lts"
-    version: 20211218+51
+    version: 20211218+52
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -141,7 +141,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-470-lts"
-    version: 470.182.03+8
+    version: 470.182.03+9
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -30,7 +30,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-guest-additions-lts"
-    version: 7.0.4+33
+    version: 7.0.4+34
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -213,7 +213,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xone-lts"
-    version: 0.3+61
+    version: 0.3+62
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -235,7 +235,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8812au-lts"
-    version: 20220827+59
+    version: 20220827+60
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -15,7 +15,7 @@ packages:
   #        version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 7.0.4+33
+    version: 7.0.4+34
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -116,7 +116,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-515-lts"
-    version: 515.105.01+8
+    version: 515.105.01+9
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -166,7 +166,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-legacy-lts"
-    version: 390.157+49
+    version: 390.157+50
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -191,7 +191,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xpadneo-lts"
-    version: 0.9.5+61
+    version: 0.9.5+62
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -301,7 +301,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8192eu-lts"
-    version: 20230313+8
+    version: 20230313+9
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -67,7 +67,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-lts"
-    version: 525.89.02+15
+    version: 525.89.02+16
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -279,7 +279,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl88x2bu-lts"
-    version: 20211010+42
+    version: 20211010+43
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-lts-sources"
     hidden: true
-    version: 6.1.27+2
+    version: "6.1.29"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -12,7 +12,7 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "6.1.27"
+      package.version: "6.1.29"
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true


### PR DESCRIPTION
walks UDP package into bar A.