### PR TITLE
Bump kernel/mocaccino-lts-full to 6.1.30

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/kernel/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/kernel/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-full
 category: kernel
-version: "6.1.29"
+version: "6.1.30"
 requires:
   - name: "mocaccino-lts-modules"
     category: "kernel"
@@ -26,4 +26,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.29"
+  package.version: "6.1.30"


### PR DESCRIPTION
“Yeah,” reply the bytes. “Make us a double.”