### PR TITLE
Bump kernel/mocaccino-lts-modules to 6.1.33

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "6.1.32"
+version: "6.1.33"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.32"
+  package.version: "6.1.33"


### PR DESCRIPTION
Gits N' Roses: Now with more git cherry-pop, git freebase, and starring git Slash!