### PR TITLE
Bump kernel/mocaccino-modules to 6.3.9

### DIFF
--- a/packages/kernels/kernels/mocaccino/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-modules
 category: kernel
-version: "6.3.7"
+version: "6.4.2"
 prefix: linux
 suffix: mocaccino
 arch: "x86_64"
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "6.3.7"
+  package.version: "6.4.2"


### PR DESCRIPTION
![runtimeError](./images/runtimeError.jpg)