### PR TITLE
Bump kernel/mocaccino-lts-sources to 6.1.38

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/sources/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-sources
 category: kernel
-version: "6.1.35"
+version: "6.1.38"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.35"
+  package.version: "6.1.38"


### PR DESCRIPTION
Answer: ![umbrella](./images/umbrella.gif)