### PR TITLE
Bump kernel-sources/mocaccino-lts-sources to 6.1.39

### DIFF
--- a/packages/apps/virtualbox/definition.yaml
+++ b/packages/apps/virtualbox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "virtualbox"
-version: 7.0.8a+10
+version: 7.0.8a+11
 uri:
   - https://www.virtualbox.org
 license: "GPL-2"

--- a/packages/buildbases/collection.yaml
+++ b/packages/buildbases/collection.yaml
@@ -28,7 +28,7 @@ packages:
   - !!merge <<: *X
     real_category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 0+182
+    version: 0+183
   - !!merge <<: *X
     real_category: "apps"
     name: "pavucontrol-qt"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -254,7 +254,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl88x2bu-lts"
-    version: 20211010+60
+    version: 20211010+61
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -67,7 +67,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-lts"
-    version: 525.116.04+12
+    version: 525.116.04+13
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -116,7 +116,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-470-lts"
-    version: 470.199.02+5
+    version: 470.199.02+6
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -15,7 +15,7 @@ packages:
   #        version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 7.0.8+10
+    version: 7.0.8+11
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -232,7 +232,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "vhba-lts"
-    version: 20211218+69
+    version: 20211218+70
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -141,7 +141,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-legacy-lts"
-    version: 390.157+67
+    version: 390.157+68
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -166,7 +166,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xpadneo-lts"
-    version: 0.9.5+79
+    version: 0.9.5+80
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -188,7 +188,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xone-lts"
-    version: 0.3+79
+    version: 0.3+80
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -210,7 +210,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8812au-lts"
-    version: 20220827+77
+    version: 20220827+78
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -276,7 +276,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8192eu-lts"
-    version: 20230313+26
+    version: 20230313+27
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -30,7 +30,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-guest-additions-lts"
-    version: 7.0.8+10
+    version: 7.0.8+11
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-lts-sources"
     hidden: true
-    version: 6.1.38+4
+    version: "6.1.41"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -12,7 +12,7 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "6.1.38"
+      package.version: "6.1.41"
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true


### PR DESCRIPTION
git-fetch: no training required