### PR TITLE
Bump kernel-sources/mocaccino-sources to 6.4.6

### DIFF
--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -92,7 +92,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers"
-    version: 525.116.04+11
+    version: 525.116.04+12
     lts: false
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -16,7 +16,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true
-    version: 6.4.3+2
+    version: "6.4.7"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -26,4 +26,4 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-      package.version: "6.4.3"
+      package.version: "6.4.7"


### PR DESCRIPTION
git-nom --omnom: eats all your tasty code