### PR TITLE
Bump kernel/mocaccino-lts-minimal to 6.1.42

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/minimal/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/minimal/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-minimal
 category: kernel
-version: "6.1.41"
+version: "6.1.42"
 kernelprefix: kernel-vanilla
 arch: "x86_64"
 suffix: mocaccino
@@ -18,4 +18,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.41"
+  package.version: "6.1.42"


### PR DESCRIPTION
Two bytes meet. The first byte asks, “Are you ill?”