### PR TITLE
Bump kernel/mocaccino-lts-modules to 6.1.45

### DIFF
--- a/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "6.1.44"
+version: "6.1.46"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "6.1.44"
+  package.version: "6.1.46"


### PR DESCRIPTION
![cluedont](https://raw.githubusercontent.com/shrutikapoor08/devjoke/aa1789ca045c6106a61173fe794466646da47629/images/joke-usb.jpg)