### PR TITLE
Bump kernel-sources/mocaccino-sources to 6.5.2

### DIFF
--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -96,7 +96,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers"
-    version: 525.116.04+25
+    version: 525.116.04+26
     lts: false
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -16,7 +16,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true
-    version: 6.4.12+2
+    version: "6.5.2"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -26,4 +26,4 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-      package.version: "6.4.12"
+      package.version: "6.5.2"


### PR DESCRIPTION
![java](./images/android-kot-java.jpg)