### PR TITLE
Bump kernel-sources/mocaccino-lts-sources to 6.1.56

### DIFF
--- a/packages/apps/virtualbox/definition.yaml
+++ b/packages/apps/virtualbox/definition.yaml
@@ -1,6 +1,6 @@
 category: "apps"
 name: "virtualbox"
-version: 7.0.10+6
+version: 7.0.10+7
 uri:
   - https://www.virtualbox.org
 license: "GPL-2"

--- a/packages/buildbases/collection.yaml
+++ b/packages/buildbases/collection.yaml
@@ -28,7 +28,7 @@ packages:
   - !!merge <<: *X
     real_category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 0+204
+    version: 0+205
   - !!merge <<: *X
     real_category: "apps"
     name: "pavucontrol-qt"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -19,7 +19,7 @@ packages:
   #         version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-modules-lts"
-    version: 7.0.10+6
+    version: 7.0.10+7
     lts: true
     emerge:
       jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -236,7 +236,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "vhba-lts"
-    version: 20211218+90
+    version: 20211218+91
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -170,7 +170,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xpadneo-lts"
-    version: 0.9.5+99
+    version: 0.9.5+100
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -120,7 +120,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-470-lts"
-    version: 470.199.02+26
+    version: 470.199.02+27
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -34,7 +34,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "virtualbox-guest-additions-lts"
-    version: 7.0.10+7
+    version: 7.0.10+8
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -71,7 +71,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-lts"
-    version: 525.116.04+32
+    version: 525.116.04+33
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -192,7 +192,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "xone-lts"
-    version: 0.3+99
+    version: 0.3+100
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -214,7 +214,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8812au-lts"
-    version: 20220827+97
+    version: 20220827+98
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -145,7 +145,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "nvidia-drivers-legacy-lts"
-    version: 390.157+88
+    version: 390.157+89
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -258,7 +258,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl88x2bu-lts"
-    version: 20211010+80
+    version: 20211010+81
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-modules/collection.yaml
+++ b/packages/kernel-modules/kernel-modules/collection.yaml
@@ -280,7 +280,7 @@ packages:
         version: ">=0"
   - category: "kernel-modules"
     name: "rtl8192eu-lts"
-    version: 20230313+46
+    version: 20230313+47
     lts: true
     labels:
       emerge.jobs: "3"

--- a/packages/kernel-modules/kernel-sources/collection.yaml
+++ b/packages/kernel-modules/kernel-sources/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "kernel-sources"
     name: "mocaccino-lts-sources"
     hidden: true
-    version: 6.1.55+2
+    version: "6.1.56"
     labels:
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
@@ -12,7 +12,7 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "6.1.55"
+      package.version: "6.1.56"
   - category: "kernel-sources"
     name: "mocaccino-sources"
     hidden: true


### PR DESCRIPTION
git-bisect: No, not like that. Grow up.